### PR TITLE
Fixes for slow mo capturing

### DIFF
--- a/reframework/autorun/NoKillCam+SlowMo.lua
+++ b/reframework/autorun/NoKillCam+SlowMo.lua
@@ -126,7 +126,7 @@ end
 local function GetMonsterActivateType(isEndQuest)
 	local isRampage = sdk.get_managed_singleton("snow.QuestManager"):call("isHyakuryuQuest");
 	if isEndQuest then
-		if (isRampage and settings.activateForAllMonsters) or (not settings.activateForAllMonsters) then
+		if (isRampage and settings.activateForAllMonsters) or (not isRampage) then
 			return true;
 		end
 	else
@@ -239,8 +239,7 @@ local function CheckShouldActivate()
 		end
 	end
 
-	if not activateOnCapture and lastHitEnemy then
-		
+	if not settings.activateOnCapture and lastHitEnemy then
 		local dieInfo = nil;
 		pcall(function() 
 			dieInfo = lastHitEnemy:call("getNowDieInfo");
@@ -250,10 +249,6 @@ local function CheckShouldActivate()
 		if dieInfo and dieInfo == 2 then
 			return;
 		end
-	end
-
-	if sdk.get_managed_singleton("snow.QuestManager"):call("isHyakuryuQuest") then
-		return;
 	end
 
 	if lastHitPlayerIdx < 0 then
@@ -380,6 +375,8 @@ local function PreRequestCamChange(args)
 			else
 				return;
 			end
+		elseif isSlowMo and endFlow <= 1 and endCapture == 2 then
+			return sdk.PreHookResult.SKIP_ORIGINAL;
 		elseif settings.disableOtherCams then
 			return sdk.PreHookResult.SKIP_ORIGINAL;
 		end
@@ -435,6 +432,11 @@ local function PreDmgCalc(args)
 end
 
 local function PrePlayerAttack(args)
+
+	if settings.activateByAnyPlayer then
+		lastHitPlayerIdx = 0
+		return;
+	end
 
 	local enemy = sdk.to_managed_object(args[2]);
 	local isBoss = get_isBossEnemy:call(enemy);


### PR DESCRIPTION
Hey @BoltManGuy,

thanks for this awesome mod! 

I had problems with the capture in slow mo, so I looked a bit deeper.

I want to explain the following changes:
* Fixed `activateOnCapture` in `CheckShouldActivate` by using the proper value stored in settings `settings.activateOnCapture`.

* In `GetMonsterActivateType` adjusted the endQuest logic. AFAIK this functions should return true if it is an end quest but not an rampage. If it is not a rampage quest and `activateForAllMonsters` is set to true, we would never active the slow mo correctly.

* Deletion of `if sdk.get_managed_singleton("snow.QuestManager"):call("isHyakuryuQuest") then` inside `CheckShouldActivate` because this check is already done properly inside `GetMonsterActivateType` (which is called prior to this function). It would not work inside a rampage quest at all even if `activateForAllMonsters` would be true.

* Added `elseif isSlowMo and endFlow <= 1 and endCapture == 2 then` in `PreRequestCamChange`. For whatever reason, when capturing, sometimes the cam would be in the endFlow state 1 (while slow mo is active) and change to the overview cam again. This line fixes that.

* An early return inside `PrePlayerAttack` because we do not need to make these checks if `activateByAnyPlayer` is true.